### PR TITLE
tcp: tidy tcp_connect functions

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -54,10 +54,10 @@ Functions and files
 ftp.h
 ~~~~~~
 char * ftp_getline(ftp_t*);
+char * ftp_getdataport(ftp_t*);
 char * ftp_pwd(ftp_t *ftp);
 int ftp_banner(ftp_t*);
 int ftp_login(ftp_t*);
-int ftp_getdataport(ftp_t*);
 int ftp_size(ftp_t*, char*);
 void ftp_list(ftp_t*, char*,int);
 void ftp_remove(ftp_t*, char*);
@@ -72,8 +72,7 @@ void ftp_mdtm(ftp_t*, char*);
 
 tcp.h
 ~~~~~~
-FILE * tcp_connect(char*, char*);
-FILE * tcp_connect2(char*, int, char*);
+FILE * tcp_connect(char*, char*, char*);
 
 utils.h
 ~~~~~~~~

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
 Thanks to
 ===========
 
-# name (email) - (comment)
+# Jamie Bainbridge (jamie.bainbridge@gmail.com) - Tidy of tcp_connect functions

--- a/src/ftp.h
+++ b/src/ftp.h
@@ -13,7 +13,7 @@
 typedef struct {
 	FILE *FD;
 	int code;
-	int dataport;
+	char *dataport;
 	unsigned int alarm_sec;
 	int logged;
 	char *user;
@@ -24,10 +24,10 @@ typedef struct {
 
 /* prototypes */
 char * ftp_getline(ftp_t*);
+char * ftp_getdataport(ftp_t*);
 char * ftp_pwd(ftp_t *ftp);
 int ftp_banner(ftp_t*);
 int ftp_login(ftp_t*);
-int ftp_getdataport(ftp_t*);
 int ftp_size(ftp_t*, char*);
 void ftp_list(ftp_t*, char*,int);
 void ftp_remove(ftp_t*, char*);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -3,7 +3,7 @@
 #include "tcp.h"
 
 /* Connect to TCP/IP socket */
-FILE * tcp_connect(char *server, char *port) {
+FILE * tcp_connect(char *server, char *port, char *mode) {
 	struct addrinfo ai, *srv = NULL, *p = NULL;
 
 	memset(&ai, 0, sizeof(struct addrinfo));
@@ -11,7 +11,6 @@ FILE * tcp_connect(char *server, char *port) {
 		die("Cannot resolve %s - (%s)", server,gai_strerror(1));
 	}
 
-	/* only IPv4*/
 	ai.ai_family = AF_UNSPEC;
 	ai.ai_socktype = SOCK_STREAM;
 	ai.ai_protocol = IPPROTO_TCP;
@@ -27,52 +26,12 @@ FILE * tcp_connect(char *server, char *port) {
 	/* skod.h //int fd */
 	if (( fd = socket(p->ai_family, p->ai_socktype, 0)) < 0 )
 		die("Failed to create socket.");
-      
-	if ( connect(fd, p->ai_addr, p->ai_addrlen) < 0 )
-		die("Failed to connect.");
-	freeaddrinfo(srv);
-
-	/* call to fdopen to return FILE */
-	return (fdopen(fd, FD_MODE));
-}
-
-
-/* IPv6/IPv4 */
-FILE * tcp_connect2(char *server, int port, char *mode) {
-	struct addrinfo ai, *srv = NULL, *p = NULL;
-	char po[MAX_STR];
-		
-	sprintf(po, "%d", port);
-	memset(&ai, 0, sizeof(struct addrinfo));
-	if (( getaddrinfo(server, po, &ai, &srv)) != 0 ) {
-		die("Cannot resolve %s - (%s)", server,gai_strerror(1));
-	}
-
-	ai.ai_family = AF_UNSPEC;
-	ai.ai_socktype = SOCK_STREAM;
-	ai.ai_protocol = IPPROTO_TCP;
-
-	p = srv;
-	if (( getnameinfo((struct sockaddr *)p->ai_addr,
-					p->ai_addrlen, 
-					ip, sizeof(ip),
-					NULL, (socklen_t) 0U, 
-					NI_NUMERICHOST)) != 0)
-		die("Cannot resolve %s- (%s).", server,gai_strerror(1));
-
-	/* skod.h //int fd */
-	if (( fd = socket(p->ai_family, 
-					p->ai_socktype, 0)) < 0 )
-		die("Failed to create socket.");
-      
 
 	if ( connect(fd, p->ai_addr, p->ai_addrlen) < 0 )
 		die("Failed to connect.");
-	
 	freeaddrinfo(srv);
 
 	/* call to fdopen to return FILE */
 	return (fdopen(fd, mode));
 }
-
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -6,7 +6,6 @@
 #include "skod.h"
 
 /* prototypes */
-FILE * tcp_connect(char*, char*);
-FILE * tcp_connect2(char*, int, char*);
+FILE * tcp_connect(char*, char*, char*);
 
 #endif /*TCP_H*/


### PR DESCRIPTION
Combines `tcp_connect()` and `tcp_connect2()` into one function.

`tcp_connect2()` was just a wrapper around `sprintf()` for the `dataport` number. The string conversion is put into `ftp_getdataport()` instead.

Signed-off-by: Jamie Bainbridge <jamie dot bainbridge at gmail dot com>